### PR TITLE
Improve C99 Compatibility

### DIFF
--- a/src/CEnum.jl
+++ b/src/CEnum.jl
@@ -22,7 +22,7 @@ Base.read(io::IO, ::Type{T}) where {T<:Cenum} = T(read(io, basetype(T)))
 
 Base.isless(x::T, y::T) where {T<:Cenum} = isless(basetype(T)(x), basetype(T)(y))
 
-Base.Symbol(x::Cenum)::Symbol = get(namemap(typeof(x)), Integer(x), :UnkownMember)
+Base.Symbol(x::Cenum)::Symbol = get(namemap(typeof(x)), Integer(x), :UnknownMember)
 
 Base.print(io::IO, x::Cenum) = print(io, Symbol(x))
 

--- a/src/CEnum.jl
+++ b/src/CEnum.jl
@@ -1,127 +1,149 @@
+# copied from https://github.com/JuliaLang/julia/pull/30924
+# modified to be in compliance with C99: http://port70.net/~nsz/c/c99/n1256.html#6.7.2.2
 module CEnum
 
-abstract type Cenum{T} end
-
-Base.:|(a::T, b::T) where {T<:Cenum{UInt32}} = UInt32(a) | UInt32(b)
-Base.:|(a::T, b::UInt32) where {T<:Cenum{UInt32}} = UInt32(a) | b
-Base.:|(a::UInt32, b::T) where {T<:Cenum{UInt32}} = b | a
-
-Base.:&(a::T, b::T) where {T<:Cenum{UInt32}} = UInt32(a) & UInt32(b)
-Base.:&(a::T, b::UInt32) where {T<:Cenum{UInt32}} = UInt32(a) & b
-Base.:&(a::UInt32, b::T) where {T<:Cenum{UInt32}} = b & a
-
-Base.:(==)(a::Integer, b::Cenum{T}) where {T<:Integer} = a == T(b)
-Base.:(==)(a::Cenum, b::Integer) = b == a
-
-Base.:+(a::S, b::T) where {S<:Integer,T<:Cenum} = a + S(b)
-Base.:+(a::T, b::S) where {S<:Integer,T<:Cenum} = S(a) + b
-Base.:-(a::S, b::T) where {S<:Integer,T<:Cenum} = a - S(b)
-Base.:-(a::T, b::S) where {S<:Integer,T<:Cenum} = S(a) - b
-
-# typemin and typemax won't change for an enum, so we might as well inline them per type
-Base.typemax(::Type{T}) where {T<:Cenum} = last(enum_values(T))
-Base.typemin(::Type{T}) where {T<:Cenum} = first(enum_values(T))
-
-Base.convert(::Type{Integer}, x::Cenum{T}) where {T<:Integer} = Base.bitcast(T, x)
-Base.convert(::Type{T}, x::Cenum{T2}) where {T<:Integer,T2<:Integer} = convert(T, Base.bitcast(T2, x))
-
-(::Type{T})(x::Cenum{T2}) where {T<:Integer,T2<:Integer} = T(Base.bitcast(T2, x))::T
-(::Type{T})(x) where {T<:Cenum} = convert(T, x)
-
-Base.write(io::IO, x::Cenum) = write(io, Int32(x))
-Base.read(io::IO, ::Type{T}) where {T<:Cenum} = T(read(io, Int32))
-
-enum_values(::T) where {T<:Cenum} = enum_values(T)
-enum_names(::T) where {T<:Cenum} = enum_names(T)
-
-is_member(::Type{T}, x::Integer) where {T<:Cenum} = is_member(T, enum_values(T), x)
-
-@inline is_member(::Type{T}, r::UnitRange, x::Integer) where {T<:Cenum} = x in r
-@inline function is_member(::Type{T}, values::Tuple, x::Integer) where {T<:Cenum}
-    lo, hi = typemin(T), typemax(T)
-    x<lo || x>hi && return false
-    for val in values
-        val == x && return true
-        val > x && return false # is sorted
-    end
-    return false
-end
-
-function enum_name(x::T) where {T<:Cenum}
-    index = something(findfirst(isequal(x), enum_values(T)), 0)
-    if index != 0
-        return enum_names(T)[index]
-    end
-    error("Invalid enum: $(Int(x)), name not found")
-end
-
-Base.show(io::IO, x::Cenum) = print(io, enum_name(x), "($(Int(x)))")
-
-function islinear(array)
-    isempty(array) && return false # false, really? it's kinda undefined?
-    lastval = first(array)
-    for val in Iterators.rest(array, 2)
-        val-lastval == 1 || return false
-    end
-    return true
-end
-
-
-macro cenum(name, args...)
-    if Meta.isexpr(name, :curly)
-        typename, type = name.args
-        typename = esc(typename)
-        typesize = 8*sizeof(getfield(Base, type))
-        typedef_expr = :(primitive type $typename <: CEnum.Cenum{$type} $typesize end)
-    elseif isa(name, Symbol)
-        # default to UInt32
-        typename = esc(name)
-        type = UInt32
-        typedef_expr = :(primitive type $typename <: CEnum.Cenum{UInt32} 32 end)
-    else
-        error("Name must be symbol or Name{Type}. Found: $name")
-    end
-    lastval = -1
-    name_values = map([args...]) do arg
-        if isa(arg, Symbol)
-            lastval += 1
-            val = lastval
-            sym = arg
-        elseif arg.head == :(=) || arg.head == :kw
-            sym,val = arg.args
-            lastval = val
-        else
-            error("Expression of type $arg not supported. Try only symbol or name = value")
-        end
-        (sym, val)
-    end
-    sort!(name_values, by=last) # sort for values
-    values = map(last, name_values)
-
-    if islinear(values) # optimize for linear values
-        values = :($(first(values)):$(last(values)))
-    else
-        values = :(tuple($(values...)))
-    end
-    value_block = Expr(:block)
-
-    for (ename, value) in name_values
-        push!(value_block.args, :(const $(esc(ename)) = $typename($value)))
-    end
-
-    expr = quote
-        $typedef_expr
-        function Base.convert(::Type{$typename}, x::Integer)
-            is_member($typename, x) || Base.Enums.enum_argument_error($(Expr(:quote, name)), x)
-            Base.bitcast($typename, convert($type, x))
-        end
-        CEnum.enum_names(::Type{$typename}) = tuple($(map(x-> Expr(:quote, first(x)), name_values)...))
-        CEnum.enum_values(::Type{$typename}) = $values
-        $value_block
-    end
-    expr
-end
+import Core.Intrinsics.bitcast
 export @cenum
 
+function namemap end
+
+"""
+    Cenum{T<:Integer}
+The abstract supertype of all enumerated types defined with [`@cenum`](@ref).
+"""
+abstract type Cenum{T<:Integer} end
+
+basetype(::Type{<:Cenum{T}}) where {T<:Integer} = T
+
+(::Type{T})(x::Cenum{T2}) where {T<:Integer,T2<:Integer} = T(bitcast(T2, x))::T
+Base.cconvert(::Type{T}, x::Cenum{T2}) where {T<:Integer,T2<:Integer} = T(x)
+Base.write(io::IO, x::Cenum{T}) where {T<:Integer} = write(io, T(x))
+Base.read(io::IO, ::Type{T}) where {T<:Cenum} = T(read(io, basetype(T)))
+
+Base.isless(x::T, y::T) where {T<:Cenum} = isless(basetype(T)(x), basetype(T)(y))
+
+Base.Symbol(x::Cenum) = namemap(typeof(x))[Integer(x)]::Symbol
+
+Base.print(io::IO, x::Cenum) = print(io, Symbol(x))
+
+function Base.show(io::IO, x::Cenum)
+    sym = Symbol(x)
+    if !get(io, :compact, false)
+        from = get(io, :module, Main)
+        def = typeof(x).name.module
+        if from === nothing || !Base.isvisible(sym, def, from)
+            show(io, def)
+            print(io, ".")
+        end
+    end
+    print(io, sym)
+end
+
+function Base.show(io::IO, ::MIME"text/plain", x::Cenum)
+    print(io, x, "::")
+    show(IOContext(io, :compact => true), typeof(x))
+    print(io, " = ")
+    show(io, Integer(x))
+end
+
+function Base.show(io::IO, ::MIME"text/plain", t::Type{<:Cenum})
+    print(io, "Cenum ")
+    Base.show_datatype(io, t)
+    print(io, ":")
+    for x in instances(t)
+        print(io, "\n", Symbol(x), " = ")
+        show(io, Integer(x))
+    end
+end
+
+# give Cenum types scalar behavior in broadcasting
+Base.broadcastable(x::Cenum) = Ref(x)
+
+@noinline enum_argument_error(typename, x) = throw(ArgumentError(string("input value out of range for Cenum $(typename): $x")))
+
+macro cenum(T, syms...)
+    if isempty(syms)
+        throw(ArgumentError("no arguments given for Cenum $T"))
+    end
+    basetype = Int32
+    typename = T
+    if isa(T, Expr) && T.head == :(::) && length(T.args) == 2 && isa(T.args[1], Symbol)
+        typename = T.args[1]
+        basetype = Core.eval(__module__, T.args[2])
+        if !isa(basetype, DataType) || !(basetype <: Integer) || !isbitstype(basetype)
+            throw(ArgumentError("invalid base type for Cenum $typename, $T=::$basetype; base type must be an integer primitive type"))
+        end
+    elseif !isa(T, Symbol)
+        throw(ArgumentError("invalid type expression for Cenum $T"))
+    end
+    seen = Set{Symbol}()
+    name_values = Tuple{Symbol,basetype}[]
+    namemap = Dict{basetype,Symbol}()
+    lo = hi = 0
+    i = zero(basetype)
+
+    if length(syms) == 1 && syms[1] isa Expr && syms[1].head == :block
+        syms = syms[1].args
+    end
+    for s in syms
+        s isa LineNumberNode && continue
+        if isa(s, Symbol)
+            if i == typemin(basetype) && !isempty(name_values)
+                throw(ArgumentError("overflow in value \"$s\" of Cenum $typename"))
+            end
+        elseif isa(s, Expr) &&
+               (s.head == :(=) || s.head == :kw) &&
+               length(s.args) == 2 && isa(s.args[1], Symbol)
+            i = Core.eval(__module__, s.args[2]) # allow exprs, e.g. uint128"1"
+            if !isa(i, Integer)
+                throw(ArgumentError("invalid value for Cenum $typename, $s; values must be integers"))
+            end
+            i = convert(basetype, i)
+            s = s.args[1]
+        else
+            throw(ArgumentError(string("invalid argument for Cenum ", typename, ": ", s)))
+        end
+        if !Base.isidentifier(s)
+            throw(ArgumentError("invalid name for Cenum $typename; \"$s\" is not a valid identifier"))
+        end
+        haskey(namemap, i) || (namemap[i] = s;)
+        push!(name_values, (s,i))
+        if s in seen
+            throw(ArgumentError("name \"$s\" in Cenum $typename is not unique"))
+        end
+        push!(seen, s)
+        if length(name_values) == 1
+            lo = hi = i
+        else
+            lo = min(lo, i)
+            hi = max(hi, i)
+        end
+        i += oneunit(i)
+    end
+    blk = quote
+        # enum definition
+        Base.@__doc__(primitive type $(esc(typename)) <: Cenum{$(basetype)} $(sizeof(basetype) * 8) end)
+        function $(esc(typename))(x::Integer)
+            x ≤ typemax(x) || enum_argument_error($(Expr(:quote, typename)), x)
+            return bitcast($(esc(typename)), convert($(basetype), x))
+        end
+        CEnum.namemap(::Type{$(esc(typename))}) = $(esc(namemap))
+        Base.typemin(x::Type{$(esc(typename))}) = $(esc(typename))($lo)
+        Base.typemax(x::Type{$(esc(typename))}) = $(esc(typename))($hi)
+        let insts = ntuple(i->$(esc(typename))($(name_values[i-1][2])), $(length(name_values)))
+            Base.instances(::Type{$(esc(typename))}) = insts
+        end
+    end
+    if isa(typename, Symbol)
+        for (sym, i) in name_values
+            push!(blk.args, :(const $(esc(sym)) = $(esc(typename))($i)))
+        end
+    end
+    push!(blk.args, :nothing)
+    blk.head = :toplevel
+    return blk
+end
+
+include("operators.jl")
 
 end # module

--- a/src/CEnum.jl
+++ b/src/CEnum.jl
@@ -22,7 +22,7 @@ Base.read(io::IO, ::Type{T}) where {T<:Cenum} = T(read(io, basetype(T)))
 
 Base.isless(x::T, y::T) where {T<:Cenum} = isless(basetype(T)(x), basetype(T)(y))
 
-Base.Symbol(x::Cenum) = namemap(typeof(x))[Integer(x)]::Symbol
+Base.Symbol(x::Cenum)::Symbol = get(namemap(typeof(x)), Integer(x), :UnkownMember)
 
 Base.print(io::IO, x::Cenum) = print(io, Symbol(x))
 

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -1,0 +1,15 @@
+import Base: +, -, *, &, |, xor, ==
+
+for op in (:+, :-, :&, :|, :xor, :(==))
+    @eval begin
+        function ($op)(a::Cenum{T}, b::Cenum{S}) where {T<:Integer,S<:Integer}
+            N = promote_type(T, S)
+            ($op)(N(a), N(b))
+        end
+        function ($op)(a::Cenum{T}, b::S) where {T<:Integer,S<:Integer}
+            N = promote_type(T, S)
+            ($op)(N(a), N(b))
+        end
+        ($op)(a::S, b::Cenum{T}) where {T<:Integer,S<:Integer} = ($op)(b, a)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,14 +1,19 @@
 using CEnum
 using Test
 
+@cenum(ZeroOne, zero, one)
+@test zero == 0
+@test one == 1
+
 @cenum(Fruit, apple=1, orange=2, kiwi=2)
 @test orange == kiwi
 @test apple | orange == 3
 @test apple & orange == 0
 @test apple + 1 == 2
 @test kiwi - 1 == 1
+@test kiwi ⊻ kiwi == 0
 
-@cenum(Boolean{Bool}, alternativefact, fact)
+@cenum(Boolean::Bool, alternativefact, fact)
 @test alternativefact == false
 
 @cenum(Day, Mon=1, Tue, Wed=3, suiyoubi=3, Fri=5, Sat)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,7 @@ using Test
 @test apple + 1 == 2
 @test kiwi - 1 == 1
 @test kiwi ⊻ kiwi == 0
+@test_nowarn print(Fruit(apple | orange))
 
 @cenum(Boolean::Bool, alternativefact, fact)
 @test alternativefact == false


### PR DESCRIPTION
This is just a copy of [the enum.jl from Julia Base](https://github.com/JuliaLang/julia/blob/db1fc0a7209554080ce896f049a1cf91b7f33257/base/Enums.jl), with minimal tweaks to be in compliance with the [C99](http://port70.net/~nsz/c/c99/n1256.html#6.7.2.2) standard:

>Constraints
>
>2 The expression that defines the value of an enumeration constant shall be an integer constant expression that has a value representable as an int.

>Semantics
>
>3 The identifiers in an enumerator list are declared as constants that have type int and may appear wherever such are permitted.109) An enumerator with = defines its enumeration constant as the value of the constant expression. If the first enumerator has no =, the value of its enumeration constant is 0. Each subsequent enumerator with no = defines its enumeration constant as the value of the constant expression obtained by adding 1 to the value of the previous enumeration constant. (The use of enumerators with = **may produce enumeration constants with values that duplicate other values in the same enumeration**.) The enumerators of an enumeration are also known as its members.

>4 Each enumerated type shall be compatible with char, a signed integer type, or an unsigned integer type. **The choice of type is implementation-defined**,110) but shall be capable of representing the values of all the members of the enumeration. The enumerated type is incomplete until after the } that terminates the list of enumerator declarations.

>Footnotes
>
>109) Thus, **the identifiers of enumeration constants declared in the same scope shall all be distinct from each other** and from other identifiers declared in ordinary declarators.
>
>**110) An implementation may delay the choice of which integer type until all enumeration constants have been seen.**

I don't find anywhere in the standard that specifies the behavior when casting a non-member Integer to Enum, so it is now allowed and the `show` method will mark it as `UnkownMember`.

As for those bitwise operators, `UInt32` is no longer being treated specially, the return type is promoted. However, it's still an `Integer` since this is the default behavior of many C/C++ compilers.
One needs to either overload the operator or explicitly cast the return value to the target enum type.    

cc @maleadt @SimonDanisch 