### PR TITLE
Remove a no-op line, fix #18

### DIFF
--- a/src/CEnum.jl
+++ b/src/CEnum.jl
@@ -125,7 +125,6 @@ macro cenum(T, syms...)
         # enum definition
         Base.@__doc__(primitive type $(esc(typename)) <: Cenum{$(basetype)} $(sizeof(basetype) * 8) end)
         function $(esc(typename))(x::Integer)
-            x ≤ typemax(x) || enum_argument_error($(Expr(:quote, typename)), x)
             return bitcast($(esc(typename)), convert($(basetype), x))
         end
         CEnum.namemap(::Type{$(esc(typename))}) = $(esc(namemap))


### PR DESCRIPTION
As pointed in #18, the condition always gives `true`, hence a no-op.