### PR TITLE
Add shift operators

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CEnum"
 uuid = "fa961155-64e5-5f13-b03f-caf6b980ea82"
-version = "0.4.2"
+version = "0.5.0"
 
 [compat]
 julia = "1.0"

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -1,6 +1,6 @@
-import Base: +, -, *, &, |, xor, ==, ~
+import Base: +, -, *, &, |, xor, ==, ~, <<, >>
 
-for op in (:+, :-, :&, :|, :xor, :(==))
+for op in (:+, :-, :&, :|, :xor, :(==), :<<, :>>)
     @eval begin
         function ($op)(a::Cenum{T}, b::Cenum{S}) where {T<:Integer,S<:Integer}
             N = promote_type(T, S)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,3 +27,17 @@ using Test
 
 # issue #11
 @test 0 - one == -1
+
+# These tests are derived from https://en.cppreference.com/w/c/language/operator_arithmetic section "Shift operators"
+# Here we test to ensure our promotion behavior matches that of C
+@cenum var"##SHIFT_TEST_SIGNED#1"::Int64 begin
+    SHIFT_TEST_N1000 = -1000
+end
+@cenum var"##SHIFT_TEST_UNSIGNED#1"::UInt64 begin
+    SHIFT_TEST_123 = 0x123
+    SHIFT_TEST_10 = 0x10
+end
+@test SHIFT_TEST_123 << 1 == 0x246
+@test SHIFT_TEST_123 << 63 == 0x8000000000000000
+@test SHIFT_TEST_10 << 10 == 0x4000
+@test SHIFT_TEST_N1000 >> 1 == -500


### PR DESCRIPTION
This PR adds support for C's shift operators.
This feature is needed because Clang.jl can emit code like the test I added, which is a method error otherwise.
